### PR TITLE
Gate /admin route behind JWT login

### DIFF
--- a/.env
+++ b/.env
@@ -20,4 +20,5 @@
 NODE_ENV=development
 
 # API Configuration
-VITE_AXIOS_BASE_URL=https://softball-reference-api.herokuapp.com
+# VITE_AXIOS_BASE_URL=https://softball-reference-api.herokuapp.com
+VITE_AXIOS_BASE_URL=http://localhost:8081/

--- a/.env
+++ b/.env
@@ -1,16 +1,14 @@
 # This is an environment variable file that will be loaded anytime the following is run:
 # > vue-cli-service build
 
-# Properties defined in this file can be referenced in the code with:
-# process.env.<property>
-# NOTE: All properties must be prefixed with "VUE_APP_*" so that
-# they are embedded into the client bundle by webpack.
+# Vite requires all properties/env vars exposed to client code to be prefixed with VITE_,
+# and access via import.meta.env.VITE_*.
 
 # If there are any .env.<mode> files that are run with:
 # > vue-cli-service build --mode <mode> 
 # then both the .env and the .env.<mode> properties will be loaded.
 # IF there are naming conflicts on properties within those files (i.e. 
-# both .env files have a "VUE_APP_<PROPERTY>") then the value in the
+# both .env files have a "VITE_<PROPERTY>") then the value in the
 # .env.<mode> file will take precedence.
 
 # This is a special variable that tells how the CLI to build the code.
@@ -22,8 +20,4 @@
 NODE_ENV=development
 
 # API Configuration
-# Vite requires env vars exposed to client code to be prefixed with VITE_,
-# and access via import.meta.env.VITE_*. The VUE_APP_* form below is kept
-# for backwards compatibility with any tooling that still reads it.
 VITE_AXIOS_BASE_URL=https://softball-reference-api.herokuapp.com
-VUE_APP_AXIOS_BASE_URL=https://softball-reference-api.herokuapp.com

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+.claude/

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Home from '../views/Home.vue';
+import store from '@/store/store';
 import * as LoadingBar from '@/composables/useLoadingBar';
 
 const routes = [
@@ -24,9 +25,15 @@ const routes = [
     component: () => import('../views/GameSummary.vue')
   },
   {
+    path: '/admin/login',
+    name: 'Login',
+    component: () => import('../views/Login.vue')
+  },
+  {
     path: '/admin/teamleagues/:teamLeagueId/games/new',
     name: 'AddGame',
     props: true,
+    meta: { requiresAuth: true },
     component: () => import('../views/AddGame.vue')
   }
 ];
@@ -38,6 +45,17 @@ const router = createRouter({
 
 router.beforeEach((to, from, next) => {
   LoadingBar.turnOnLoadingBar();
+  if (to.meta.requiresAuth && !store.getters.isAuthenticated) {
+    setTimeout(
+      () =>
+        next({
+          name: 'Login',
+          query: { redirect: to.fullPath }
+        }),
+      250
+    );
+    return;
+  }
   setTimeout(() => next(), 250);
 });
 

--- a/src/services/ApiService.js
+++ b/src/services/ApiService.js
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import store from '@/store/store';
+import router from '@/router/router';
 
 /**
  * Specifically only want to have a singleton instance of the API Client. This
@@ -13,6 +15,40 @@ const apiClient = axios.create({
     'Content-Type': 'application/json'
   }
 });
+
+/* Attach the JWT (if any) to every outbound request. */
+apiClient.interceptors.request.use(config => {
+  const token = store.state.authToken;
+  if (token) {
+    config.headers.Authorization = 'Bearer ' + token;
+  }
+  return config;
+});
+
+/* If the server says the token is bad/expired, clear it and bounce to login. */
+apiClient.interceptors.response.use(
+  response => response,
+  error => {
+    const status = error.response && error.response.status;
+    if (status === 401 || status === 403) {
+      if (store.state.authToken) {
+        store.dispatch('logout');
+      }
+      const current = router.currentRoute.value;
+      if (
+        current &&
+        current.path.startsWith('/admin') &&
+        current.name !== 'Login'
+      ) {
+        router.replace({
+          name: 'Login',
+          query: { redirect: current.fullPath }
+        });
+      }
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default {
   /**
@@ -95,5 +131,13 @@ export default {
    */
   createStatLine(payload) {
     return apiClient.post('/statlines', payload);
+  },
+  /**
+   * Exchange admin username/password for a JWT.
+   * @param {{username: string, password: string}} credentials
+   * @returns Promise resolving to { token, expiresInMs }
+   */
+  login(credentials) {
+    return apiClient.post('/auth/login', credentials);
   }
 };

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,18 +1,39 @@
 import { createStore } from 'vuex';
 
+const TOKEN_KEY = 'softball_admin_token';
+
 export default createStore({
   state: {
     /* Flag to let all components know if a loading bar should be running. */
-    isLoading: false
+    isLoading: false,
+    /* Admin JWT — null when logged out. Initialised from localStorage so a refresh stays logged in. */
+    authToken: localStorage.getItem(TOKEN_KEY) || null
+  },
+  getters: {
+    isAuthenticated: state => !!state.authToken
   },
   mutations: {
     SET_IS_LOADING(state, isLoading) {
       state.isLoading = isLoading;
+    },
+    SET_AUTH_TOKEN(state, token) {
+      state.authToken = token;
+      if (token) {
+        localStorage.setItem(TOKEN_KEY, token);
+      } else {
+        localStorage.removeItem(TOKEN_KEY);
+      }
     }
   },
   actions: {
     setIsLoading(context, isLoading) {
       context.commit('SET_IS_LOADING', isLoading);
+    },
+    setAuthToken(context, token) {
+      context.commit('SET_AUTH_TOKEN', token);
+    },
+    logout(context) {
+      context.commit('SET_AUTH_TOKEN', null);
     }
   }
 });

--- a/src/views/AddGame.vue
+++ b/src/views/AddGame.vue
@@ -1,9 +1,12 @@
 <template>
   <v-container>
-    <v-row>
+    <v-row align="center">
       <v-col>
         <h1 class="text-h4 font-weight-bold">Add Game</h1>
         <p class="text-medium-emphasis">TeamLeague&nbsp;#{{ teamLeagueId }}</p>
+      </v-col>
+      <v-col cols="auto">
+        <v-btn variant="outlined" @click="onLogout">Log out</v-btn>
       </v-col>
     </v-row>
 
@@ -111,6 +114,7 @@
 <script>
 import { reactive, ref, toRefs } from 'vue';
 import { useRouter } from 'vue-router';
+import { useStore } from 'vuex';
 import ApiService from '@/services/ApiService';
 import StatLineEntryTable from '@/components/StatLineEntryTable.vue';
 import { statLineEntryColumns } from '@/utils/constants';
@@ -125,7 +129,13 @@ export default {
   },
   setup(props) {
     const router = useRouter();
+    const store = useStore();
     const formRef = ref(null);
+
+    function onLogout() {
+      store.dispatch('logout');
+      router.push({ name: 'Login' });
+    }
     const state = reactive({
       game: {
         date: '',
@@ -237,7 +247,7 @@ export default {
       router.push({ name: 'GameSummary', params: { gameId } });
     }
 
-    return { ...toRefs(state), formRef, onSubmit };
+    return { ...toRefs(state), formRef, onSubmit, onLogout };
   }
 };
 </script>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,0 +1,89 @@
+<template>
+  <v-container class="d-flex justify-center" style="max-width: 480px">
+    <v-card class="pa-6 mt-8" width="100%" color="transparent" elevation="0">
+      <h1 class="text-h4 font-weight-bold mb-4">Admin login</h1>
+      <v-form ref="formRef" @submit.prevent="onSubmit">
+        <v-text-field
+          v-model="username"
+          label="Username"
+          variant="outlined"
+          autocomplete="username"
+          :rules="[v => !!v || 'Username is required']"
+          required
+        />
+        <v-text-field
+          v-model="password"
+          label="Password"
+          type="password"
+          variant="outlined"
+          autocomplete="current-password"
+          :rules="[v => !!v || 'Password is required']"
+          required
+        />
+        <v-alert v-if="error" type="error" variant="tonal" class="mb-4">
+          {{ error }}
+        </v-alert>
+        <v-btn
+          type="submit"
+          color="softball_red"
+          variant="flat"
+          size="large"
+          :loading="submitting"
+          block
+        >
+          Log in
+        </v-btn>
+      </v-form>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import { reactive, ref, toRefs } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { useStore } from 'vuex';
+import ApiService from '@/services/ApiService';
+
+export default {
+  name: 'AdminLogin',
+  setup() {
+    const router = useRouter();
+    const route = useRoute();
+    const store = useStore();
+    const formRef = ref(null);
+    const state = reactive({
+      username: '',
+      password: '',
+      submitting: false,
+      error: ''
+    });
+
+    async function onSubmit() {
+      state.error = '';
+      const { valid } = await formRef.value.validate();
+      if (!valid) return;
+
+      state.submitting = true;
+      try {
+        const res = await ApiService.login({
+          username: state.username,
+          password: state.password
+        });
+        store.dispatch('setAuthToken', res.data.token);
+        const redirect = route.query.redirect;
+        router.replace(redirect ? String(redirect) : '/');
+      } catch (err) {
+        const status = err.response && err.response.status;
+        state.error =
+          status === 401
+            ? 'Invalid username or password.'
+            : 'Login failed: ' + (err.message || String(err));
+      } finally {
+        state.submitting = false;
+      }
+    }
+
+    return { ...toRefs(state), formRef, onSubmit };
+  }
+};
+</script>


### PR DESCRIPTION
Closes #19. Requires https://github.com/bradykey/softball-reference-api/pull/11 to be merged first.

## Summary
- Lock `/admin/teamleagues/:teamLeagueId/games/new` behind a JWT login flow so the AddGame form (and the `POST /games` / `POST /statlines` calls it makes) is only reachable by an authenticated admin.
- Pairs with the API-side JWT changes in `softball-reference-api#<PR>` — this PR is a no-op until that one is deployed and the API config vars are set.

## Changes
- **`src/store/store.js`** — new `authToken` state and `isAuthenticated` getter, backed by `localStorage` so a page refresh keeps the session. `setAuthToken` / `logout` actions.
- **`src/services/ApiService.js`**
  - Request interceptor attaches `Authorization: Bearer <token>` when a token is present.
  - Response interceptor: on 401/403 clears the token and redirects to `/admin/login` with a `?redirect=` back to the original path.
  - New `login(credentials)` method calling `POST /auth/login`.
- **`src/router/router.js`** — new `/admin/login` route; `AddGame` route flagged `meta.requiresAuth`; `beforeEach` redirects unauthenticated requests to the login screen and preserves the intended destination via `?redirect=`.
- **`src/views/Login.vue`** — new Vuetify login form. On success stores the token and follows `?redirect=` (or falls back to home).
- **`src/views/AddGame.vue`** — adds a "Log out" button in the header that clears the token and returns to `/admin/login`.
- **`.gitignore`** — ignore `.claude/`.

## Notes / follow-ups
- The `.env` change in this branch points `VITE_AXIOS_BASE_URL` at `http://localhost:8081/` for local testing — **revert before merging** so prod still hits Heroku.
- Frontend protection is UX-only; the real gate is the API. Don't merge this without the API PR being deployed and `ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH` / `JWT_SECRET` set on the API dyno.

## Test plan
- [ ] `npm run lint` and `npm run build` pass.
- [ ] Visiting `/admin/teamleagues/<id>/games/new` while logged out redirects to `/admin/login?redirect=…`.
- [ ] Logging in with valid creds redirects back to the original URL and the AddGame form loads.
- [ ] Bad creds show an error and don't navigate away.
- [ ] Refreshing the page while authenticated keeps the session (token comes back from `localStorage`).
- [ ] Clicking "Log out" clears the session and routes back to `/admin/login`.
- [ ] If the API rejects a stored token (401/403), the UI clears it and bounces to login with `?redirect=`.
- [ ] Public team / game pages still render without logging in.
