### PR TITLE
Correctly point to API in prod instead of localhost

### DIFF
--- a/.env
+++ b/.env
@@ -20,5 +20,5 @@
 NODE_ENV=development
 
 # API Configuration
-# VITE_AXIOS_BASE_URL=https://softball-reference-api.herokuapp.com
-VITE_AXIOS_BASE_URL=http://localhost:8081/
+VITE_AXIOS_BASE_URL=https://softball-reference-api.herokuapp.com
+# VITE_AXIOS_BASE_URL=http://localhost:8081/


### PR DESCRIPTION
Accidentally committed localhost:8081 instead of https://softball-reference-api.herokuapp.com