### PR TITLE
Admin UX polish: admin shortcut, add-game button, AddGame improvements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -42,7 +42,7 @@
         aria-label="Admin"
         class="mr-2"
       >
-        <v-icon>mdi-shield-account</v-icon>
+        <v-icon>mdi-cog</v-icon>
       </v-btn>
     </v-app-bar>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@
       </div>
 
       <v-divider class="mx-4" vertical></v-divider>
-      <v-row class="ml-2">
+      <v-row class="ml-2" align="center" no-gutters>
         <v-menu offset-y>
           <template v-slot:activator="{ props: menuProps }">
             <v-chip color="softball_red" variant="flat" v-bind="menuProps">
@@ -35,6 +35,15 @@
           </v-list>
         </v-menu>
       </v-row>
+      <v-btn
+        icon
+        variant="text"
+        :to="{ name: 'AdminHome' }"
+        aria-label="Admin"
+        class="mr-2"
+      >
+        <v-icon>mdi-shield-account</v-icon>
+      </v-btn>
     </v-app-bar>
 
     <v-main>

--- a/src/views/AddGame.vue
+++ b/src/views/AddGame.vue
@@ -14,24 +14,36 @@
       <v-card class="pa-4 mb-4" color="transparent" elevation="0">
         <v-card-title class="px-0">Game details</v-card-title>
         <v-row>
-          <v-col cols="12" md="4">
+          <v-col cols="12" md="3">
             <v-text-field
               v-model="game.date"
-              type="datetime-local"
-              label="Date / time"
+              type="date"
+              label="Date"
               variant="outlined"
               :rules="[v => !!v || 'Date is required']"
               required
             />
           </v-col>
-          <v-col cols="12" md="4">
+          <v-col cols="12" md="3">
+            <v-select
+              v-model="game.time"
+              :items="timeOptions"
+              item-title="title"
+              item-value="value"
+              label="Start time"
+              variant="outlined"
+              :rules="[v => !!v || 'Time is required']"
+              required
+            />
+          </v-col>
+          <v-col cols="12" md="3">
             <v-text-field
               v-model="game.opponent"
               label="Opponent"
               variant="outlined"
             />
           </v-col>
-          <v-col cols="12" md="4">
+          <v-col cols="12" md="3">
             <v-text-field
               v-model="game.field"
               label="Field"
@@ -136,9 +148,16 @@ export default {
       store.dispatch('logout');
       router.push({ name: 'Login' });
     }
+    const timeOptions = [
+      { title: '6:30 PM', value: '18:30' },
+      { title: '7:30 PM', value: '19:30' },
+      { title: '8:30 PM', value: '20:30' }
+    ];
+
     const state = reactive({
       game: {
         date: '',
+        time: '',
         opponent: '',
         field: '',
         wasHome: true,
@@ -191,7 +210,7 @@ export default {
       LoadingBar.turnOnLoadingBar();
 
       const gamePayload = {
-        date: toBackendDateString(state.game.date),
+        date: toBackendDateString(`${state.game.date}T${state.game.time}`),
         opponent: state.game.opponent || null,
         score: state.game.score,
         opponentScore: state.game.opponentScore,
@@ -247,7 +266,7 @@ export default {
       router.push({ name: 'GameSummary', params: { gameId } });
     }
 
-    return { ...toRefs(state), formRef, onSubmit, onLogout };
+    return { ...toRefs(state), timeOptions, formRef, onSubmit, onLogout };
   }
 };
 </script>

--- a/src/views/AddGame.vue
+++ b/src/views/AddGame.vue
@@ -3,7 +3,7 @@
     <v-row align="center">
       <v-col>
         <h1 class="text-h4 font-weight-bold">Add Game</h1>
-        <p class="text-medium-emphasis">TeamLeague&nbsp;#{{ teamLeagueId }}</p>
+        <p class="text-medium-emphasis">{{ subtitle }}</p>
       </v-col>
       <v-col cols="auto">
         <v-btn variant="outlined" @click="onLogout">Log out</v-btn>
@@ -124,7 +124,7 @@
 </template>
 
 <script>
-import { reactive, ref, toRefs } from 'vue';
+import { computed, reactive, ref, toRefs } from 'vue';
 import { useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 import ApiService from '@/services/ApiService';
@@ -143,6 +143,12 @@ export default {
     const router = useRouter();
     const store = useStore();
     const formRef = ref(null);
+
+    const subtitle = computed(() =>
+      state.teamName && state.leagueName
+        ? `${state.teamName} — ${state.leagueName}`
+        : `TeamLeague #${props.teamLeagueId}`
+    );
 
     function onLogout() {
       store.dispatch('logout');
@@ -164,6 +170,8 @@ export default {
         score: 0,
         opponentScore: 0
       },
+      teamName: null,
+      leagueName: null,
       lineup: [],
       bench: [],
       errors: [],
@@ -181,6 +189,17 @@ export default {
       });
       return row;
     }
+
+    LoadingBar.turnOnLoadingBar();
+    ApiService.getSeasonSummaryStatLines(props.teamLeagueId)
+      .then(response => {
+        state.teamName = response.data.team;
+        state.leagueName = response.data.league;
+      })
+      .catch(error => console.log(error))
+      .finally(() => {
+        LoadingBar.turnOffLoadingBar();
+      });
 
     LoadingBar.turnOnLoadingBar();
     ApiService.getRoster(props.teamLeagueId)
@@ -266,7 +285,14 @@ export default {
       router.push({ name: 'GameSummary', params: { gameId } });
     }
 
-    return { ...toRefs(state), timeOptions, formRef, onSubmit, onLogout };
+    return {
+      ...toRefs(state),
+      timeOptions,
+      subtitle,
+      formRef,
+      onSubmit,
+      onLogout
+    };
   }
 };
 </script>

--- a/src/views/TeamLeagueSummary.vue
+++ b/src/views/TeamLeagueSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container v-if="!Utils.isObjectUndefinedEmptyOrNull(teamLeagues)">
-    <v-row>
+    <v-row align="center">
       <v-col>
         <TitleCard
           :title="team"
@@ -9,6 +9,19 @@
           :titleChipColor="CustomColors.softball_red"
           :divider="true"
         />
+      </v-col>
+      <v-col v-if="isAuthenticated && currTeamLeague" cols="auto">
+        <v-btn
+          color="softball_red"
+          variant="flat"
+          prepend-icon="mdi-plus"
+          :to="{
+            name: 'AddGame',
+            params: { teamLeagueId: currTeamLeague.teamLeagueId }
+          }"
+        >
+          Add Game
+        </v-btn>
       </v-col>
     </v-row>
     <v-row>
@@ -74,6 +87,7 @@ import ApiService from '@/services/ApiService';
 import CustomColors from '@/plugins/vuetify/theme.js';
 import { computed, reactive, toRefs, watch } from 'vue';
 import { onBeforeRouteLeave } from 'vue-router';
+import { useStore } from 'vuex';
 import * as Utils from '@/utils/utils.js';
 import * as LoadingBar from '@/composables/useLoadingBar';
 
@@ -95,6 +109,9 @@ export default {
     GameSummaryTable
   },
   setup(props) {
+    const store = useStore();
+    const isAuthenticated = computed(() => store.getters.isAuthenticated);
+
     const state = reactive({
       teamLeagues: null,
       currTeamLeague: null,
@@ -224,6 +241,7 @@ export default {
       team,
       recordSummarySubtitle,
       record,
+      isAuthenticated,
       CustomColors,
       Utils
     };


### PR DESCRIPTION
## Summary
  - Add a cog button in the app bar that routes to Admin Home.
  - Add an "Add Game" button to TeamLeagueSummary (visible when authed) that jumps straight into AddGame
  with the current season's `teamLeagueId`.
  - On AddGame: replace the native `datetime-local` with a date field + a 3-option time select (6:30 /
  7:30 / 8:30 PM); show the real Team — League name in the subtitle by calling `/teamleagues/:id` instead
  of the bare `TeamLeague #N`.