### PR TITLE
Use lightweight teamleagues/:id/info endpoint instead of heavy statlines for basic team league information

### DIFF
--- a/src/services/ApiService.js
+++ b/src/services/ApiService.js
@@ -87,7 +87,16 @@ export default {
     return apiClient.get('/teamleagues/' + teamLeagueId);
   },
   /**
-   * Retrive the GameSummaries for a TeamLeague. This is wrapped in a
+   * Retrieve the TeamLeague information associated with the TeamLeagueId.
+   *
+   * @param {int} teamLeagueId the Id of the TeamLeague to retrieve
+   * @returns The TeamLeagueBindResponse for the TeamLeagueId passed in.
+   */
+  getTeamLeagueById(teamLeagueId) {
+    return apiClient.get('/teamleagues/' + teamLeagueId + '/info');
+  },
+  /**
+   * Retrieve the GameSummaries for a TeamLeague. This is wrapped in a
    * GameSummaryResponse from the API and contains information about each game
    * associated with this TeamLeague.
    * @param {int} teamLeagueId the Id of the TeamLeague / Season to retrive the
@@ -95,7 +104,7 @@ export default {
    * @returns The array of GameSummaryResponses associated with the TeamLeagueId
    * passed in.
    */
-  getGamesByTeamLeague(teamLeagueId) {
+  getGamesByTeamLeagueId(teamLeagueId) {
     return apiClient.get('/teamleagues/' + teamLeagueId + '/games');
   },
   /**

--- a/src/views/AddGame.vue
+++ b/src/views/AddGame.vue
@@ -191,7 +191,7 @@ export default {
     }
 
     LoadingBar.turnOnLoadingBar();
-    ApiService.getSeasonSummaryStatLines(props.teamLeagueId)
+    ApiService.getTeamLeagueById(props.teamLeagueId)
       .then(response => {
         state.teamName = response.data.team;
         state.leagueName = response.data.league;

--- a/src/views/TeamLeagueSummary.vue
+++ b/src/views/TeamLeagueSummary.vue
@@ -216,7 +216,7 @@ export default {
               LoadingBar.turnOffLoadingBar();
             });
 
-          ApiService.getGamesByTeamLeague(newCurrTeamLeague.teamLeagueId)
+          ApiService.getGamesByTeamLeagueId(newCurrTeamLeague.teamLeagueId)
             .then(response => {
               state.games = response.data;
             })


### PR DESCRIPTION
Added the /teamleagues/:id/info endpoint and used it in the AddGame view to save round trip time instead of calling a full summary stat line.

Must be merged after https://github.com/bradykey/softball-reference-api/pull/13